### PR TITLE
erase 501 response part

### DIFF
--- a/draft-momoka-httpbis-settings-enable-websockets.md
+++ b/draft-momoka-httpbis-settings-enable-websockets.md
@@ -108,8 +108,8 @@ Other protocols such as {{?WEBTRANSPORT=I-D.draft-ietf-webtrans-overview}} also 
 
 Suppose the server supports Extended CONNECT and has a wss::// URL, but does not support
 bootstrapping WebSockets over this HTTP connection.
-In this case, a client trying to initiate a WebSocket handshake using Extended CONNECT will fail,
-and the client would need to fall back to trying the WebSocket handshake over HTTP/1.
+In this case, a client attempting to initiate a WebSocket handshake using Extended CONNECT will fail,
+and the client would need to create a WebSocket connection using the HTTP/1.1 Upgrade mechanism.
 
 This is why a SETTINGS_ENABLE_WEBSOCKETS settings parameter is needed.
 

--- a/draft-momoka-httpbis-settings-enable-websockets.md
+++ b/draft-momoka-httpbis-settings-enable-websockets.md
@@ -106,8 +106,9 @@ Support for the extended CONNECT mechanism is advertised using HTTP/2 and HTTP/3
 However, the support of extended CONNECT does not necessarily indicate support for WebSockets over that HTTP connection.
 Other protocols such as {{?WEBTRANSPORT=I-D.draft-ietf-webtrans-overview}} also use extended CONNECT and send SETTINGS_ENABLE_CONNECT_PROTOCOL settings parameters as well.
 
-Suppose the server supports extended CONNECT but not bootstrapping WebSockets over that HTTP connection.
-In this case, the client sending a WebSocket handshake request will result in a response of 501 (Not Implemented) status code (Section 15.6.2 of {{HTTP}}),
+Suppose the server supports Extended CONNECT and has a wss::// URL, but does not support
+bootstrapping WebSockets over this HTTP connection.
+In this case, a client trying to initiate a WebSocket handshake using Extended CONNECT will fail,
 and the client would need to fall back to trying the WebSocket handshake over HTTP/1.
 
 This is why a SETTINGS_ENABLE_WEBSOCKETS settings parameter is needed.

--- a/draft-momoka-httpbis-settings-enable-websockets.md
+++ b/draft-momoka-httpbis-settings-enable-websockets.md
@@ -106,10 +106,11 @@ Support for the extended CONNECT mechanism is advertised using HTTP/2 and HTTP/3
 However, the support of extended CONNECT does not necessarily indicate support for WebSockets over that HTTP connection.
 Other protocols such as {{?WEBTRANSPORT=I-D.draft-ietf-webtrans-overview}} also use extended CONNECT and send SETTINGS_ENABLE_CONNECT_PROTOCOL settings parameters as well.
 
-Suppose the server supports Extended CONNECT and has a wss::// URL, but does not support
-bootstrapping WebSockets over this HTTP connection.
-In this case, a client attempting to initiate a WebSocket handshake using Extended CONNECT will fail,
-and the client would need to create a WebSocket connection using the HTTP/1.1 Upgrade mechanism.
+Suppose the server supports Extended CONNECT and has a wss::// URL, but does not
+support bootstrapping WebSockets over this HTTP connection.
+In this case, a client attempting to initiate a WebSocket handshake using
+Extended CONNECT will fail, and the client would need to create a WebSocket
+connection using the HTTP/1.1 Upgrade mechanism.
 
 This is why a SETTINGS_ENABLE_WEBSOCKETS settings parameter is needed.
 


### PR DESCRIPTION
Erased the part about the 501 response error code because we do not know how servers will react when they do not support RFC8441 or 9221 and receive a request.